### PR TITLE
Fix layout metadata and countdown redirect

### DIFF
--- a/app/dashboard/layout.jsx
+++ b/app/dashboard/layout.jsx
@@ -4,14 +4,16 @@ import Theming from "@/components/providers/Theme";
 export default function RootLayout({ children }) {
   return (
     <html lang="hu">
-      <title>PromNET - Polyák Csaba E.V.</title>
+      <head>
+        <title>PromNET - Polyák Csaba E.V.</title>
         <meta name="description" content="Weboldal fejlesztés gyorsan, olcsón!" />
         <meta property="og:title" content="PromNET - Polyák Csaba E.V." />
         <meta property="og:description" content="Weboldal fejlesztés gyorsan, olcsón!" />
-        <meta property="og:image" content="/logo-whiute.png" />
+        <meta property="og:image" content="/logo-white.png" />
         <meta property="og:url" content="https://www.promnet.hu" />
         <meta name="twitter:card" content="summary_large_image" />
-      <body className="">
+      </head>
+      <body className="bg-[#171717]">
         <Theming>
           <div className="max-w-[78rem] mx-auto ">
             <div className=" gap-4 flex md:mt-5    flex-col md:flex-row  ">

--- a/app/page.js
+++ b/app/page.js
@@ -1,23 +1,27 @@
 "use client";
 import Image from "next/image";
 import Link from "next/link";
-import { useState, useEffect } from "react"; // useState és useEffect importálása
+import { useState, useEffect } from "react";
+import { useRouter } from "next/navigation";
 
 function Page() {
-  const [countdown, setCountdown] = useState(3); // Visszaszámláló állapota 3-mal
+  const router = useRouter();
+  const [countdown, setCountdown] = useState(3);
 
   useEffect(() => {
     const timer = setInterval(() => {
-      setCountdown((prev) => prev - 1); // Visszaszámláló frissítése
-    }, 1000); // Visszaszámláló 1 másodperces frissítése
+      setCountdown((prev) => {
+        if (prev <= 1) {
+          clearInterval(timer);
+          router.push("/dashboard");
+          return 0;
+        }
+        return prev - 1;
+      });
+    }, 1000);
 
-    if (countdown === 0) {
-      clearInterval(timer);
-      window.location.href = "/dashboard"; // Átirányítás a /dashboard oldalra
-    }
-
-    return () => clearInterval(timer); // Visszatéréskor a timer törlése
-  }, [countdown]); // A függőség tömb tartalmazza a countdown állapotot
+    return () => clearInterval(timer);
+  }, [router]);
 
   return (
     <div className="relative min-h-screen overflow-hidden flex flex-col items-center justify-center">


### PR DESCRIPTION
## Summary
- update `app/dashboard/layout.jsx` head structure and fix logo path
- simplify countdown redirect logic in `app/page.js`

## Testing
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_6845516066f88325b90877aed58026eb