### PR TITLE
Fix tooltip container className formatting

### DIFF
--- a/app/TestimonialTooltip/page.jsx
+++ b/app/TestimonialTooltip/page.jsx
@@ -57,11 +57,7 @@ function TestimonialTooltip() {
   ];
 
   return (
-    <div
-      className="flex flex-row items-center gap-x-9  
-    cursor-pointer
-    "
-    >
+    <div className="flex flex-row items-center gap-x-9 cursor-pointer">
       {people.map((testimonial, idx) => (
         <div
           className="-mr-4  relative group"


### PR DESCRIPTION
## Summary
- fix the tooltip container div so the className is declared on a single line
- prevent JSX syntax errors that broke rendering of the TestimonialTooltip component

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68f38e444e2c8325a3a9d24cdff33106