### PR TITLE
Update Cloudflare compatibility date

### DIFF
--- a/wrangler.toml
+++ b/wrangler.toml
@@ -1,4 +1,4 @@
 name = "promnet"
-compatibility_date = "2024-05-27"
+compatibility_date = "2024-09-23"
 compatibility_flags = ["nodejs_compat"]
 pages_build_output_dir = ".vercel/output/static"


### PR DESCRIPTION
## Summary
- update the Cloudflare Workers compatibility date to 2024-09-23 so the runtime provides the async_hooks module that Next.js expects on Pages deployments

## Testing
- npm run build
- npx wrangler pages dev .vercel/output/static (curl -I /, curl -I /dashboard)

------
https://chatgpt.com/codex/tasks/task_e_68f38fa9c1988325be19395ce36a1773