### PR TITLE
Remove right sidebar widgets from dashboard layout

### DIFF
--- a/app/dashboard/layout.jsx
+++ b/app/dashboard/layout.jsx
@@ -1,13 +1,11 @@
-import View from "@/app/ui/dashboard/View/page";
 import Left from "@/app/dashboard/Left/page";
 
 export default function DashboardLayout({ children }) {
   return (
-    <div className="max-w-[78rem] mx-auto">
-      <div className="gap-4 flex md:mt-5 flex-col md:flex-row">
+    <div className="mx-auto max-w-[78rem]">
+      <div className="flex flex-col gap-4 md:mt-5 md:flex-row">
         <Left />
         {children}
-        <View />
       </div>
     </div>
   );


### PR DESCRIPTION
## Summary
- remove the right-side view component from the dashboard layout so the main content can use the full width
- tidy the layout container classes after removing the extra column

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68f3ad36c87c83258a40a0212e8996b3