### PR TITLE
Add missing Vercel integrations and fix case studies page client mode

### DIFF
--- a/app/dashboard/case-studies/page.jsx
+++ b/app/dashboard/case-studies/page.jsx
@@ -1,3 +1,5 @@
+'use client';
+
 import Link from "next/link";
 import { motion } from "framer-motion";
 import { PiArrowLeftThin } from "react-icons/pi";

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,8 @@
       "dependencies": {
         "@editorjs/editorjs": "^2.28.1",
         "@tailwindcss/container-queries": "^0.1.1",
+        "@vercel/analytics": "^1.5.0",
+        "@vercel/speed-insights": "^1.2.0",
         "classnames": "^2.3.2",
         "fast-xml-parser": "^4.4.0",
         "framer-motion": "^10.16.4",
@@ -2519,6 +2521,44 @@
       "integrity": "sha512-zuVdFrMJiuCDQUMCzQaD6KL28MjnqqN8XnAqiEq9PNm/hCPTSGfrXCOfwj1ow4LFb/tNymJPwsNbVePc1xFqrQ==",
       "dev": true
     },
+    "node_modules/@vercel/analytics": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/@vercel/analytics/-/analytics-1.5.0.tgz",
+      "integrity": "sha512-MYsBzfPki4gthY5HnYN7jgInhAZ7Ac1cYDoRWFomwGHWEX7odTEzbtg9kf/QSo7XEsEAqlQugA6gJ2WS2DEa3g==",
+      "license": "MPL-2.0",
+      "peerDependencies": {
+        "@remix-run/react": "^2",
+        "@sveltejs/kit": "^1 || ^2",
+        "next": ">= 13",
+        "react": "^18 || ^19 || ^19.0.0-rc",
+        "svelte": ">= 4",
+        "vue": "^3",
+        "vue-router": "^4"
+      },
+      "peerDependenciesMeta": {
+        "@remix-run/react": {
+          "optional": true
+        },
+        "@sveltejs/kit": {
+          "optional": true
+        },
+        "next": {
+          "optional": true
+        },
+        "react": {
+          "optional": true
+        },
+        "svelte": {
+          "optional": true
+        },
+        "vue": {
+          "optional": true
+        },
+        "vue-router": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@vercel/blob": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/@vercel/blob/-/blob-1.0.2.tgz",
@@ -3873,6 +3913,41 @@
       "dev": true,
       "license": "Apache-2.0",
       "peer": true
+    },
+    "node_modules/@vercel/speed-insights": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@vercel/speed-insights/-/speed-insights-1.2.0.tgz",
+      "integrity": "sha512-y9GVzrUJ2xmgtQlzFP2KhVRoCglwfRQgjyfY607aU0hh0Un6d0OUyrJkjuAlsV18qR4zfoFPs/BiIj9YDS6Wzw==",
+      "hasInstallScript": true,
+      "license": "Apache-2.0",
+      "peerDependencies": {
+        "@sveltejs/kit": "^1 || ^2",
+        "next": ">= 13",
+        "react": "^18 || ^19 || ^19.0.0-rc",
+        "svelte": ">= 4",
+        "vue": "^3",
+        "vue-router": "^4"
+      },
+      "peerDependenciesMeta": {
+        "@sveltejs/kit": {
+          "optional": true
+        },
+        "next": {
+          "optional": true
+        },
+        "react": {
+          "optional": true
+        },
+        "svelte": {
+          "optional": true
+        },
+        "vue": {
+          "optional": true
+        },
+        "vue-router": {
+          "optional": true
+        }
+      }
     },
     "node_modules/@vercel/static-build": {
       "version": "2.7.17",

--- a/package.json
+++ b/package.json
@@ -13,6 +13,8 @@
   "dependencies": {
     "@editorjs/editorjs": "^2.28.1",
     "@tailwindcss/container-queries": "^0.1.1",
+    "@vercel/analytics": "^1.5.0",
+    "@vercel/speed-insights": "^1.2.0",
     "classnames": "^2.3.2",
     "fast-xml-parser": "^4.4.0",
     "framer-motion": "^10.16.4",
@@ -25,13 +27,13 @@
     "resend": "^3.4.0"
   },
   "devDependencies": {
+    "@cloudflare/next-on-pages": "^1.13.13",
     "@editorjs/image": "^2.8.1",
     "autoprefixer": "^10",
     "eslint": "^8",
     "eslint-config-next": "^14.2.4",
     "postcss": "^8",
-    "tailwindcss": "^3",
-    "@cloudflare/next-on-pages": "^1.13.13"
+    "tailwindcss": "^3"
   },
   "engines": {
     "node": ">=18.17.0"


### PR DESCRIPTION
## Summary
- add the @vercel/analytics and @vercel/speed-insights dependencies required by the layout imports
- mark the dashboard case studies page as a client component so framer-motion can run

## Testing
- npm run vercel-build

------
https://chatgpt.com/codex/tasks/task_e_68f4082f7b1c8325b96260e9a58adec3