### PR TITLE
Átállítás az Edge futtatókörnyezetre az API végpontoknál

### DIFF
--- a/app/api/blog/route.js
+++ b/app/api/blog/route.js
@@ -1,7 +1,7 @@
 import { NextResponse } from "next/server";
 import { XMLParser } from "fast-xml-parser";
 
-export const runtime = "nodejs";
+export const runtime = "edge";
 
 const BLOG_FEED_URL = "https://blogocska.hu/feed";
 
@@ -40,8 +40,8 @@ const toRelativeTime = (dateString) => {
 
 export async function GET(request) {
   try {
-    const { searchParams } = new URL(request.url);
-    const limit = Number.parseInt(searchParams.get("limit") ?? "6", 10) || 6;
+    const limitParam = request.nextUrl?.searchParams?.get("limit");
+    const limit = Number.parseInt(limitParam ?? "6", 10) || 6;
 
     const response = await fetch(BLOG_FEED_URL, {
       headers: { "User-Agent": "PromNET-site" },


### PR DESCRIPTION
## Összegzés
- A blog API végpontját Edge futtatókörnyezetre állítottam és a query paraméter olvasását NextRequest kompatibilissá tettem.
- A lead API végpontját Edge kompatibilisre alakítottam, webhookos továbbítással kiváltva a fájl alapú tárolást.

## Tesztek
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68f40a94ae4483259844320baf62d662