### PR TITLE
Add missing rel attributes to external links

### DIFF
--- a/app/HomePage/page.jsx
+++ b/app/HomePage/page.jsx
@@ -380,7 +380,13 @@ function Homepage() {
 
         <div className="grid gap-6 lg:grid-cols-2">
           {quickLinks.map(({ href, media, title, subtitle }, index) => (
-            <Link key={href} href={href} target={href.startsWith("http") ? "_blank" : undefined} className="group">
+            <Link
+              key={href}
+              href={href}
+              target={href.startsWith("http") ? "_blank" : undefined}
+              rel={href.startsWith("http") ? "noopener noreferrer" : undefined}
+              className="group"
+            >
               <motion.article
                 className="flex h-full gap-5 rounded-[2rem] border border-white/10 bg-neutral-900/70 p-6 shadow-[0_20px_60px_-40px_rgba(0,0,0,0.8)] transition duration-500 group-hover:-translate-y-2 group-hover:border-white/40 group-hover:shadow-[0_30px_90px_-40px_rgba(168,85,247,0.5)]"
                 initial={enableMotion ? { opacity: 0, y: 20 } : false}
@@ -450,7 +456,7 @@ function Homepage() {
           {blogStatus.state === "error" ? (
             <div className="rounded-2xl border border-rose-500/40 bg-rose-500/10 p-4 text-sm text-rose-200">
               {blogStatus.message}{" "}
-              <Link href="https://blogocska.hu" className="underline" target="_blank">
+              <Link href="https://blogocska.hu" className="underline" target="_blank" rel="noopener noreferrer">
                 blogocska.hu
               </Link>
             </div>
@@ -471,6 +477,7 @@ function Homepage() {
                   <Link
                     href={post.link}
                     target="_blank"
+                    rel="noopener noreferrer"
                     className="inline-flex items-center gap-1 text-sky-200 transition hover:text-sky-100"
                   >
                     Elolvasom

--- a/app/dashboard/case-studies/creatify/page.jsx
+++ b/app/dashboard/case-studies/creatify/page.jsx
@@ -194,6 +194,7 @@ export default function CreatifyCaseStudyPage() {
             <Link
               href="https://cal.com/promnet/30-perces-konzultacio"
               target="_blank"
+              rel="noopener noreferrer"
               className="inline-flex items-center gap-2 rounded-full bg-neutral-900 px-5 py-2 text-sm font-RubikMedium text-emerald-100 transition hover:-translate-y-0.5 hover:bg-neutral-800"
               onClick={() => trackCtaClick("case-study-cal", { case: "creatify" })}
             >

--- a/app/dashboard/case-studies/promark/page.jsx
+++ b/app/dashboard/case-studies/promark/page.jsx
@@ -194,6 +194,7 @@ export default function PromarkCaseStudyPage() {
             <Link
               href="https://cal.com/promnet/30-perces-konzultacio"
               target="_blank"
+              rel="noopener noreferrer"
               className="inline-flex items-center gap-2 rounded-full bg-neutral-900 px-5 py-2 text-sm font-RubikMedium text-sky-100 transition hover:-translate-y-0.5 hover:bg-neutral-800"
               onClick={() => trackCtaClick("case-study-cal", { case: "promark" })}
             >

--- a/app/dashboard/service/page.jsx
+++ b/app/dashboard/service/page.jsx
@@ -392,6 +392,7 @@ function Page() {
                 <Link
                   href="https://cal.com/promnet/15-perces-gyors-egyeztetes"
                   target="_blank"
+                  rel="noopener noreferrer"
                   className="inline-flex items-center justify-center rounded-full bg-neutral-900 px-5 py-2 font-RubikMedium text-emerald-100 transition hover:-translate-y-0.5 hover:bg-neutral-800"
                   onClick={() => trackCtaClick("service-cal", { service: "it-service" })}
                 >


### PR DESCRIPTION
## Summary
- add `rel="noopener noreferrer"` to external quick link entries on the landing page
- extend the same protection to external CTAs on the case study and service pages

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68f4110c3fb08325b3e2fe15c4c5f400