### PR TITLE
Állítsd át a Wrangler előnézeti környezet nevét

### DIFF
--- a/wrangler.toml
+++ b/wrangler.toml
@@ -6,7 +6,7 @@ pages_build_output_dir = ".vercel/output/static"
 [vars]
 APP_ENV = "production"
 
-[env.staging]
+[env.preview]
 vars = { APP_ENV = "staging" }
 
 [env.production]


### PR DESCRIPTION
## Összegzés
- a Pages konfigurációban az `env.staging` szekciót `env.preview` névre cseréltem, hogy a támogatott környezetnév legyen használatban

## Tesztek
- nincs lefuttatott automatizált teszt

------
https://chatgpt.com/codex/tasks/task_e_68f6363983148325b52352de12d83803