### PR TITLE
Finomított kártyafelület árnyékokkal

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -94,11 +94,13 @@
 
 @layer components {
   .promnet-surface {
-    @apply rounded-3xl border bg-card/90 shadow-soft backdrop-blur-md transition-transform duration-200 ease-out;
+    @apply relative overflow-hidden rounded-[2.75rem] border border-white/10 bg-card/90 backdrop-blur-xl transition-transform duration-200 ease-out;
+    box-shadow: 0 32px 80px -44px rgba(15, 23, 42, 0.55), 0 -26px 70px -54px rgba(15, 23, 42, 0.35);
   }
 
   .promnet-surface:hover {
-    transform: translateY(-4px);
+    transform: translateY(-6px);
+    box-shadow: 0 40px 110px -52px rgba(15, 23, 42, 0.6), 0 -32px 90px -60px rgba(15, 23, 42, 0.4);
   }
 
   .promnet-grid {

--- a/lib/release-note.js
+++ b/lib/release-note.js
@@ -2,10 +2,10 @@ import packageJson from "../package.json";
 
 export const currentRelease = {
   version: packageJson.version,
-  date: "2024-09-25",
+  date: "2024-10-09",
   highlights: [
-    "Új kártyakomponens szolgáltatás és esettanulmány blokkokhoz",
-    "Consent alapú, anonim analitika és frissített biztonsági beállítások",
-    "Light/Dark automatikus téma és hozzáférhető fókuszjelölések",
+    "Új, lágyan lekerekített kártyafelületek kettős felső-alsó árnyékolással",
+    "Finomított lebegési animáció a kiemelt tartalmak hangsúlyozásához",
+    "Frissített verziószám és kiadási jegyzet a megújult felülettel összhangban",
   ],
 };

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "promnet",
-  "version": "0.7.10",
+  "version": "0.7.11",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "promnet",
-      "version": "0.7.10",
+      "version": "0.7.11",
       "dependencies": {
         "@editorjs/editorjs": "^2.28.1",
         "@tailwindcss/container-queries": "^0.1.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "promnet",
-  "version": "0.7.10",
+  "version": "0.7.11",
   "private": true,
   "scripts": {
     "email": "email dev",


### PR DESCRIPTION
## Összefoglaló
- lágyabb, lekerekített `promnet-surface` stílus kettős felső-alsó árnyékkal
- verziószám frissítése 0.7.11-re és a kiadási jegyzet aktualizálása az új felülethez

## Tesztek
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_6903086262e883259a7aee27bb6ce6e2