### PR TITLE
Frissítés: PromNET 15.10.30 jubileumi kiadás

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -94,7 +94,8 @@
 
 @layer components {
   .promnet-surface {
-    @apply relative overflow-hidden rounded-[2.75rem] border border-white/10 bg-card/90 backdrop-blur-xl transition-transform duration-200 ease-out;
+    @apply relative overflow-hidden border border-white/10 bg-card/90 backdrop-blur-xl transition-transform duration-200 ease-out;
+    border-radius: 2.75rem;
     box-shadow: 0 32px 80px -44px rgba(15, 23, 42, 0.55), 0 -26px 70px -54px rgba(15, 23, 42, 0.35);
   }
 

--- a/lib/release-note.js
+++ b/lib/release-note.js
@@ -2,10 +2,10 @@ import packageJson from "../package.json";
 
 export const currentRelease = {
   version: packageJson.version,
-  date: "2024-10-09",
+  date: "2024-10-30",
   highlights: [
     "Új, lágyan lekerekített kártyafelületek kettős felső-alsó árnyékolással",
     "Finomított lebegési animáció a kiemelt tartalmak hangsúlyozásához",
-    "Frissített verziószám és kiadási jegyzet a megújult felülettel összhangban",
+    "15 éves jubileumi kiadás: PromNET 15.10.30 és megújult kiadási jegyzet",
   ],
 };

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "promnet",
-  "version": "0.7.11",
+  "version": "15.10.30",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "promnet",
-      "version": "0.7.11",
+      "version": "15.10.30",
       "dependencies": {
         "@editorjs/editorjs": "^2.28.1",
         "@tailwindcss/container-queries": "^0.1.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "promnet",
-  "version": "0.7.11",
+  "version": "15.10.30",
   "private": true,
   "scripts": {
     "email": "email dev",


### PR DESCRIPTION
## Összegzés
- A csomagverziót 15.10.30-ra frissítettem és aktualizáltam a kiadási dátumot a 15 éves jubileumhoz.
- A kiadási jegyzetet kiegészítettem a jubileumi információval.
- A `.promnet-surface` komponensben külön beállítottam a szegélyrádiuszt, hogy a lekerekített kártyák tényleg megjelenjenek.

## Tesztelés
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_69030ebec398832595ab49fea76c3467