### PR TITLE
Lekerekített nagy panelek és igazítás

### DIFF
--- a/app/HomePage/page.jsx
+++ b/app/HomePage/page.jsx
@@ -229,7 +229,7 @@ function Homepage() {
   return (
     <motion.section
       {...heroSectionMotion}
-      className="relative w-full overflow-hidden"
+      className="relative w-full overflow-hidden rounded-[3rem]"
     >
       <div className="absolute inset-0 -z-20 bg-gradient-to-b from-[#10051c] via-neutral-950 to-black" />
       <motion.div

--- a/app/dashboard/Left/page.jsx
+++ b/app/dashboard/Left/page.jsx
@@ -307,7 +307,7 @@ function Leftpage() {
           opacity: 1,
           transition: { duration: 0.3, type: "spring", stiffness: 200 },
         }}
-        className="hidden h-fit w-full md:sticky md:top-5 md:block md:w-80 bg-[#1C1C1C]"
+        className="hidden h-fit w-full overflow-hidden rounded-[2.75rem] bg-[#1C1C1C] md:sticky md:top-5 md:block md:w-80"
       >
         <div className="h-full w-full rounded-2xl border border-neutral-800 bg-[#1C1C1C] p-3 md:w-80">
           <div className="flex">

--- a/app/dashboard/layout.jsx
+++ b/app/dashboard/layout.jsx
@@ -3,9 +3,9 @@ import Left from "@/app/dashboard/Left/page";
 export default function DashboardLayout({ children }) {
   return (
     <div className="mx-auto max-w-[78rem]">
-      <div className="flex flex-col gap-4 md:mt-5 md:flex-row">
+      <div className="flex flex-col gap-4 md:mt-5 md:flex-row md:items-start">
         <Left />
-        {children}
+        <div className="flex-1 md:self-start">{children}</div>
       </div>
     </div>
   );


### PR DESCRIPTION
## Összegzés
- Lekerekítettem a fő kezdőszekció külső konténerét, hogy a nagy hero kártya sarkai is lekerekítve jelenjenek meg.
- Lekerekítettem a bal oldali névjegy doboz külső keretét, így a teljes kártya egységesen lekerekített sarkokat kapott.
- A dashboard elrendezésén igazítottam, hogy a jobb oldali tartalom a bal oldali panelhez igazodva felül egy vonalban kezdődjön.

## Tesztelés
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_69031267c2388325a204135fec174ce3