### PR TITLE
Magyar nyelvűre fordított játék/animáció/3D fókusz

### DIFF
--- a/app/HomePage/page.jsx
+++ b/app/HomePage/page.jsx
@@ -19,14 +19,14 @@ const heroText = {
   title: (
     <>
       Üdvözöllek a <span className="text-sm font-RubikMedium text-neutral-200">PromNET</span>{" "}
-      <span className="text-sm font-Rubik text-neutral-200">oldalon!</span>
+      <span className="text-sm font-Rubik text-neutral-200">stúdióban!</span>
     </>
   ),
   description: (
     <>
-      Szia! Polyák Csaba vagyok, full stack fejlesztő, aki szenvedélyesen tervez és hoz létre modern,
-      felhasználóbarát webes megoldásokat. Tapasztalatom segít abban, hogy ügyfeleimnek egyedi és hatékony online jelenlétet
-      biztosítsak – a stratégiától az üzemeltetésig.
+      Szia! Polyák Csaba vagyok, játék- és animációkészítéssel, 3D grafikával, 3D modellezéssel és 3D nyomtatással
+      foglalkozom. Webfejlesztési megkereséseket már nem vállalok, a fókusz a kreatív és technikai 3D munkákon van az
+      ötlettől a végső átadásig.
     </>
   ),
 };
@@ -55,11 +55,11 @@ const quickLinks = [
 const services = [
   {
     href: "/dashboard/webdev",
-    title: "Webfejlesztés & UX",
+    title: "Játék, animáció & 3D",
     domain: "promnet.hu",
-    description: "Digitális termékek tervezése és fejlesztése mérésekkel, SEO-val és üzleti fókuszú UX-szel.",
+    description: "Játék- és animációkészítés, 3D grafika, 3D modellezés és 3D nyomtatás.",
     icon: <PiBrowsersThin aria-hidden="true" className="h-6 w-6" />,
-    iconAlt: "Webfejlesztés ikon",
+    iconAlt: "Játék és 3D ikon",
   },
   {
     href: "/dashboard/hostingbuilder",
@@ -81,21 +81,21 @@ const services = [
 
 const collaborationSteps = [
   {
-    title: "Felmérés és célkitűzés",
+    title: "Felmérés és irány",
     description:
-      "Közösen elemezzük a jelenlegi digitális jelenlétedet, majd meghatározzuk az üzleti célokat és mérőszámokat.",
+      "Közösen meghatározzuk a briefet, a kreatív irányt, a terjedelmet és az ütemezést a játék, animáció vagy 3D projektben.",
     icon: <PiMegaphoneThin aria-hidden="true" className="h-6 w-6 text-sky-200" />,
   },
   {
-    title: "Megoldás-tervezés",
+    title: "Gyártás és iteráció",
     description:
-      "Prototípusokat, UX koncepciót és technológiai tervet készítek, hogy pontosan lásd, milyen irányba indulunk.",
+      "Modellezés, textúrázás, animáció és interaktív prototípusok, átlátható review körökkel és frissítésekkel.",
     icon: <PiCodeThin aria-hidden="true" className="h-6 w-6 text-emerald-200" />,
   },
   {
-    title: "Megvalósítás és támogatás",
+    title: "Átadás és támogatás",
     description:
-      "Iteratív fejlesztés, folyamatos visszajelzés és átlátható státuszriportok mellett jutunk el az éles indításig.",
+      "Végső render, assetek vagy nyomtatásra kész fájlok dokumentált átadással és opcionális támogatással.",
     icon: <PiCloudThin aria-hidden="true" className="h-6 w-6 text-amber-200" />,
   },
 ];

--- a/app/dashboard/Left/page.jsx
+++ b/app/dashboard/Left/page.jsx
@@ -690,9 +690,8 @@ function Leftpage() {
           <div className="mt-5 w-full text-neutral-300">
             <h2 className="font-RubikBold my-4">Info</h2>
             <p className="text-[12px]  font-RubikRegular my-3">
-              Professzionális webfejlesztés, egyedi megoldások: Neked készítem a
-              legmenőbb weboldalt! Kreatív kódolás, ami még a macskádnak is
-              tetszeni fog. Bízd rám a weboldalad, és emelkedj ki a tömegből!{" "}
+              Játék- és animációkészítésre, 3D grafikára, 3D modellezésre és 3D nyomtatásra fókuszálok. Webfejlesztési
+              projekteket már nem vállalok, viszont kreatív 3D munkák és gyártási támogatás elérhető.
             </p>
 
             <div className="grid gap-2 rounded-xl border border-emerald-400/20 bg-neutral-900/60 p-3 text-[11px] text-neutral-200">
@@ -722,9 +721,9 @@ function Leftpage() {
                     }
                     target="blank"
                   >
-                    full stack
+                    korábbi full stack
                   </Link>{" "}
-                  webfejlesztő
+                  webfejlesztő (webes projektekre már nem vállalok megkeresést)
                 </span>
               </div>
               <div className="flex items-center gap-x-1">

--- a/app/dashboard/webdev/WebdevClient.jsx
+++ b/app/dashboard/webdev/WebdevClient.jsx
@@ -6,84 +6,84 @@ import { PiArrowLeftThin } from "react-icons/pi";
 import { motion } from "framer-motion";
 import {
   FaGlobe,
-  FaWordpress,
-  FaCode,
   FaHandshake,
-  FaServer,
   FaClock,
+  FaCubes,
+  FaPalette,
+  FaFolderOpen,
 } from "react-icons/fa";
 import { trackCtaClick } from "@/lib/analytics";
 
 const packages = [
   {
-    name: "Alap bemutatkozó",
-    price: "249 000 Ft-tól",
-    target: "Kisvállalkozások, szolgáltatók",
-    delivery: "2-3 hét",
+    name: "Játék- és animációkészítés",
+    price: "Egyedi projektár",
+    target: "Stúdiók, indie csapatok, kreatív márkák",
+    delivery: "Ütemezés a terjedelem alapján",
     features: [
-      "3-5 oldalas reszponzív weboldal",
-      "Egyedi design + arculati illesztés",
-      "Kontakt űrlap és alap analitika",
-      "1 év tárhely + domain a partner hostingban",
+      "Storyboardok, animatikok és vizuális irány",
+      "Karakter- és környezetfejlesztés",
+      "Animáció, VFX és motion design",
+      "Átadás broadcast- és web-kompatibilis formátumban",
     ],
   },
   {
-    name: "Pro webshop",
-    price: "449 000 Ft-tól",
-    target: "E-kereskedelmi projektek",
-    delivery: "3-5 hét",
+    name: "3D grafika & vizualizáció",
+    price: "Egyedi projektár",
+    target: "Termékcsapatok, marketing, vizualizáció",
+    delivery: "Ütemezés a terjedelem alapján",
     features: [
-      "Termék- és kategóriakezelés",
-      "Online fizetési integráció",
-      "Kampánymérés és konverziókövetés",
-      "Marketing automatizmusok (hírlevél, elhagyott kosár)",
+      "Fotorealisztikus renderek és turntable anyagok",
+      "Világítás, anyagok és jelenet felépítés",
+      "Animációra kész assetek és textúrák",
+      "Nagy felbontású képek és videó exportok",
     ],
   },
   {
-    name: "Egyedi rendszer",
-    price: "Egyedi ajánlat",
-    target: "Komplex, integrációt igénylő projektek",
-    delivery: "4-8 hét",
+    name: "3D modellezés & nyomtatás",
+    price: "Egyedi projektár",
+    target: "Prototípusok, gyűjtői darabok, egyedi alkatrészek",
+    delivery: "Ütemezés a terjedelem alapján",
     features: [
-      "Folyamatfeltérképezés és UX workshop",
-      "Speciális modulok (időpontfoglaló, CRM integráció)",
-      "Skálázható infrastruktúra és CI/CD",
-      "Külön karbantartási és üzemeltetési SLA",
+      "Tiszta topológia és nyomtatható mesh-ek",
+      "Tűrések és falvastagság ellenőrzés",
+      "Támasz generálás és szeletelési útmutató",
+      "FDM/SLA workflow-ra előkészített fájlok",
     ],
   },
 ];
 
 const processSteps = [
   {
-    title: "Discovery & brief",
-    description: "Közös kickoff, célmeghatározás, versenytárselemzés, technológiai stack kiválasztása.",
+    title: "Brief és kreatív irány",
+    description: "Terjedelem, referenciák, moodboardok és gyártási ütemezés megtervezése.",
   },
   {
-    title: "Wireframe & design sprint",
-    description: "Navigáció, UX-flow, prototípus és vizuális irány egyeztetése, módosítási körök dokumentálva.",
+    title: "Design és asset gyártás",
+    description: "Modellezés, textúrázás, riggelés és animáció iteratív visszajelzésekkel.",
   },
   {
-    title: "Fejlesztés & integráció",
-    description: "Reszponzív build, tartalom bekötés, tesztfázis automatizált ellenőrzésekkel (SEO, sebesség, akadálymentesség).",
+    title: "Renderelés és előkészítés",
+    description: "Világítás, render, export és csomagolás game engine, videó vagy nyomtatás számára.",
   },
   {
-    title: "Átadás & támogatás",
-    description: "Launch terv, oktató anyagok, mérési dashboard beállítása és 30 napos finomhangolási időszak.",
+    title: "Átadás és támogatás",
+    description: "Végső assetek, dokumentáció és opcionális finomhangolás az átadás után.",
   },
 ];
 
 const extras = [
   {
-    title: "Teljes körű üzemeltetés",
-    description: "Monitoring, biztonsági mentések, szerverfrissítések és SLA szerinti reakcióidő. Ideális, ha a fejlesztés után sem szeretnél technikai teendőkkel foglalkozni.",
+    title: "Game engine integráció",
+    description: "Unity vagy Unreal kompatibilis assetek, optimalizálás és LOD beállítások.",
   },
   {
-    title: "Tartalommarketing csomag",
-    description: "Landing oldalak, blogcikkek, automatizált hírlevelek – a konverziónöveléshez tartalmi támogatást is kapsz.",
+    title: "Nyomtatási teszt támogatás",
+    description: "Anyagjavaslatok, nyomtatási beállítások és tesztfutás visszajelzés.",
   },
   {
-    title: "Rendszerintegrációk",
-    description: "CRM, számlázó, készletkezelő vagy marketing eszközök összekötése biztonságos API integrációval.",
+    title: "Asset könyvtár felépítés",
+    description: "Rendszerezett forrásfájlok, elnevezési szabványok és átadási checklist.",
   },
 ];
 
@@ -140,17 +140,21 @@ function WebdevClient() {
           transition={{ delay: 0.4 }}
           className="text-3xl font-RubikExtraBold text-center text-neutral-100"
         >
-          Weboldal fejlesztés
+          Játék, animáció & 3D
         </motion.h1>
         <div className="flex items-center gap-x-2 justify-center my-4 font-RubikRegular">
           <p className="bg-[#282828] w-fit text-neutral-300 rounded-md px-2 h-5 flex items-center justify-center text-[10px]">
-            Portfolio Weboldalak, Céges oldal, Webáruház
+            Játék, animáció, 3D grafika, modellezés, 3D nyomtatás
           </p>
           <div className="w-1 h-1 rounded-full bg-neutral-400" />
           <span className="text-xs text-neutral-300">
             Frissítve: 2024.07.09.
           </span>
         </div>
+        <p className="text-center text-sm text-neutral-300">
+          Webfejlesztési szolgáltatásokat már nem vállalok. Kérlek, csak játék, animáció, 3D grafika, 3D modellezés vagy 3D
+          nyomtatás kapcsán keress.
+        </p>
         <section className="relative md:py-12 py-8">
           <div className="mt-6 grid gap-6 lg:grid-cols-3">
             {packages.map((pkg) => (
@@ -179,7 +183,7 @@ function WebdevClient() {
                   className="mt-auto inline-flex items-center gap-2 rounded-full border border-white/15 px-4 py-2 text-xs font-RubikMedium text-neutral-50 transition hover:-translate-y-0.5 hover:border-amber-300/60 hover:text-amber-100"
                   onClick={() => trackCtaClick("webdev-lead", { package: pkg.name })}
                 >
-                  Ajánlatot kérek
+                  Projekt indítása
                   <svg xmlns="http://www.w3.org/2000/svg" className="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={1.5}>
                     <path strokeLinecap="round" strokeLinejoin="round" d="M9 5l7 7-7 7" />
                   </svg>
@@ -206,33 +210,33 @@ function WebdevClient() {
               </div>
             </div>
             <div className="flex flex-col gap-4 rounded-2xl border border-emerald-400/20 bg-emerald-500/10 p-6 text-neutral-50">
-              <h3 className="text-lg font-RubikMedium">Mit tartalmaz minden csomag?</h3>
+              <h3 className="text-lg font-RubikMedium">Mit tartalmaz minden projekt?</h3>
               <ul className="space-y-3 text-sm text-neutral-100">
                 <li className="flex items-start gap-2">
-                  <FaWordpress className="mt-1 h-3.5 w-3.5 text-neutral-900" />
-                  <span>Modern, reszponzív felület optimalizálva mobilra és asztali gépre is.</span>
+                  <FaCubes className="mt-1 h-3.5 w-3.5 text-neutral-900" />
+                  <span>Átlátható scope, referenciák és gyártási roadmap.</span>
                 </li>
                 <li className="flex items-start gap-2">
-                  <FaCode className="mt-1 h-3.5 w-3.5 text-neutral-900" />
-                  <span>Egyedi fejlesztés: nem sablonból dolgozom, így a márkád is megkülönböztethető marad.</span>
+                  <FaPalette className="mt-1 h-3.5 w-3.5 text-neutral-900" />
+                  <span>Egyedi assetek, amelyek illeszkednek a márkához és az art directionhöz.</span>
                 </li>
                 <li className="flex items-start gap-2">
-                  <FaServer className="mt-1 h-3.5 w-3.5 text-neutral-900" />
-                  <span>1 év tárhely és domain partner hostingban, folyamatos státuszriporttal.</span>
+                  <FaFolderOpen className="mt-1 h-3.5 w-3.5 text-neutral-900" />
+                  <span>Verziózott átadás és rendezett projektstruktúra.</span>
                 </li>
                 <li className="flex items-start gap-2">
                   <FaHandshake className="mt-1 h-3.5 w-3.5 text-neutral-900" />
-                  <span>Transzparens kommunikáció, közös Trello / ClickUp board és heti státusz összefoglaló.</span>
+                  <span>Transzparens kommunikáció közös boardokkal és heti frissítésekkel.</span>
                 </li>
                 <li className="flex items-start gap-2">
                   <FaClock className="mt-1 h-3.5 w-3.5 text-neutral-900" />
-                  <span>Garantált határidők és launch támogatás – a weboldal az egyeztetett időre éles.</span>
+                  <span>Megbízható ütemezés és a megjelenési dátumhoz igazított átadás.</span>
                 </li>
               </ul>
             </div>
           </div>
           <div className="mt-10 grid gap-4 rounded-2xl border border-white/10 bg-neutral-900/60 p-6 text-neutral-100">
-            <h2 className="text-xl font-RubikMedium text-neutral-50">További opciók a növekedéshez</h2>
+            <h2 className="text-xl font-RubikMedium text-neutral-50">További opciók</h2>
             <div className="grid gap-4 md:grid-cols-3">
               {extras.map((extra) => (
                 <div key={extra.title} className="rounded-xl border border-white/10 bg-neutral-950/60 p-4">
@@ -242,7 +246,7 @@ function WebdevClient() {
               ))}
             </div>
             <p className="text-xs text-neutral-400">
-              Személyre szabott kombinációk is kérhetők – vedd fel a kapcsolatot velem, és segítek kiválasztani a legjobb megoldást.
+              Egyedi kombinációk is kérhetők — vedd fel a kapcsolatot, és közösen meghatározzuk a legjobb megoldást.
             </p>
           </div>
         </section>

--- a/app/layout.js
+++ b/app/layout.js
@@ -28,7 +28,7 @@ const structuredData = {
   telephone: "+36 20 549 4107",
   email: "info@promnet.hu",
   description:
-    "Full stack webfejlesztés, digitális termék- és infrastruktúra fejlesztés magyar vállalkozásoknak.",
+    "Játék- és animációkészítés, 3D grafika, 3D modellezés és 3D nyomtatás.",
   address: {
     "@type": "PostalAddress",
     streetAddress: "Kölcsey Ferenc út 11.",
@@ -46,9 +46,11 @@ const structuredData = {
     name: "Magyarország",
   },
   serviceType: [
-    "Weboldal fejlesztés",
-    "Webáruház készítés",
-    "Rendszergazdai szolgáltatás",
+    "Játékfejlesztés",
+    "Animáció",
+    "3D grafika",
+    "3D modellezés",
+    "3D nyomtatás",
     "Elektronikai szerviz",
   ],
 };

--- a/data/services.js
+++ b/data/services.js
@@ -47,12 +47,11 @@ const createServiceSchema = ({ name, description, serviceType, path, priceRange 
 
 export const serviceSchemas = {
   "/dashboard/webdev": createServiceSchema({
-    name: "Webfejlesztés és UX",
+    name: "Játék, animáció és 3D",
     description:
-      "Reszponzív weboldalak és webshopok tervezése, fejlesztése, mérési csomagokkal és folyamatos támogatással magyar vállalkozások számára.",
-    serviceType: ["Webfejlesztés", "UX tervezés", "E-kereskedelem"],
+      "Játék- és animációkészítés, 3D grafika, 3D modellezés és 3D nyomtatás kreatív és technikai projektekhez.",
+    serviceType: ["Játékfejlesztés", "Animáció", "3D grafika", "3D modellezés", "3D nyomtatás"],
     path: "/dashboard/webdev",
-    priceRange: { low: "249000", high: "800000" },
   }),
   "/dashboard/service": createServiceSchema({
     name: "Elektronikai szerviz",

--- a/lib/seo.js
+++ b/lib/seo.js
@@ -1,24 +1,25 @@
 const baseUrl = "https://www.promnet.hu";
 
 export const siteMetadata = {
-  title: "PromNET – Digitális fejlesztés és üzemeltetés",
+  title: "PromNET – Játék, animáció és 3D",
   description:
-    "PromNET: Polyák Csaba modern webfejlesztési, hosting és üzemeltetési megoldásai magyar vállalkozásoknak.",
+    "PromNET – Polyák Csaba: játék- és animációkészítés, 3D grafika, 3D modellezés és 3D nyomtatás.",
   keywords: [
-    "webfejlesztés",
-    "hosting",
-    "digitális termék",
+    "játékfejlesztés",
+    "animáció",
+    "3D grafika",
+    "3D modellezés",
+    "3D nyomtatás",
     "promnet",
     "Polyák Csaba",
-    "Next.js fejlesztő",
   ],
 };
 
 export const pageMetadata = {
   "/": {
-    title: "PromNET – Digitális fejlesztés és üzemeltetés",
+    title: "PromNET – Játék, animáció és 3D",
     description:
-      "Ismerd meg Polyák Csaba (PromNET) webfejlesztési és üzemeltetési szolgáltatásait, amelyek mérhető eredményeket hoznak.",
+      "Fedezd fel a PromNET-et: játék- és animációkészítés, 3D grafika, 3D modellezés és 3D nyomtatás.",
     changeFrequency: "weekly",
     priority: 1,
   },
@@ -30,9 +31,9 @@ export const pageMetadata = {
     priority: 0.9,
   },
   "/dashboard/webdev": {
-    title: "Webfejlesztés és UX – PromNET",
+    title: "Játék, animáció és 3D – PromNET",
     description:
-      "Reszponzív weboldalak, webshopok és digitális termékek tervezése és fejlesztése teljes körű támogatással.",
+      "Játék- és animációkészítés, 3D grafika, 3D modellezés és 3D nyomtatás. Webfejlesztési megkereséseket már nem vállalok.",
   },
   "/dashboard/service": {
     title: "Elektronikai szerviz – PromNET",


### PR DESCRIPTION
### Motivation
- A weboldal tartalmát a webfejlesztésről a játékok, animáció és 3D (modellezés & nyomtatás) irányába toltam el, és egyértelműen jeleztem, hogy webfejlesztési megrendeléseket már nem vállalok.
- A tulajdonságok és SEO/struktúra adatok magyar nyelvűre lokalizálása szükséges volt a következetes kommunikációhoz.

### Description
- A kezdőlap hős szövegét és szolgáltatás kártyáját magyarra fordítottam és a fókuszt 3D/animáció irányba módosítottam (`app/HomePage/page.jsx`).
- A `/dashboard/webdev` oldal teljes tartalmát magyar nyelvű, a 3D/játék/animáció szolgáltatásokra fókuszáló copy-ra cseréltem, csomagokkal, folyamattal és opciókkal (`app/dashboard/webdev/WebdevClient.jsx`).
- Az oldalsáv információi és státuszszövegei frissültek magyarul és jeleznek a webfejlesztés leállására (`app/dashboard/Left/page.jsx`).
- SEO metaadatok és strukturált adatok ill. a szolgáltatás séma magyar változata el lett helyezve (`lib/seo.js`, `app/layout.js`, `data/services.js`).
- Kisebb UI-szövegek és CTA-k átnevezéseit is elvégeztem (pl. gombok, listák, ikon alt szövegek); commit megtörtént.

### Testing
- Elindítottam a fejlesztői szervert `npm run dev -- --hostname 0.0.0.0 --port 3000`, a környezetben volt egy hálózati `fetch`/`ENETUNREACH` figyelmeztetés, de az alkalmazás lefordult és a `/dashboard/webdev` oldal kiszolgálása sikeres volt (`GET /dashboard/webdev 200`).
- Lefuttattam egy Playwright képernyőkép scriptet, amely sikeresen készített screenshotot (`artifacts/webdev-page-hu.png`) a frissített oldallal.
- Nem futtattam automatikus egységteszteket a változtatásokhoz; a módosításokat helyi dev szerveren és a képernyőkép alapján smoke-testeltem, amelyek sikeresek voltak (a dev szerver figyelmeztetése kivétellel).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6988474caee48325ba5d64abff23f7a1)